### PR TITLE
debian/libnss-docker.postrm: Replace perl with sed invocation (Closes: #1009642)

### DIFF
--- a/debian/libnss-docker.postrm
+++ b/debian/libnss-docker.postrm
@@ -16,14 +16,8 @@ remove_nss_entry() {
         log "Could not find /etc/nsswitch.conf."
         return
     fi
-    perl -i -pe '
-        sub remove {
-            my $s = shift;
-            $s =~ s/\s+docker(\s+\[NOTFOUND=return\])?//g;
-            return $s;
-        }
-        s/^(hosts:)(.*)/$1.remove($2)/e;
-    ' /etc/nsswitch.conf
+    sed -E -i /etc/nsswitch.conf \
+        -e 's/^(hosts:.*)(\s+docker(\s+\[NOTFOUND=return\])?)(.*)$/\1\4/g'
 }
 
 action="$1"


### PR DESCRIPTION
Using `perl` in maintscripts is problematic because Perl may no longer
be available in the future when the user purges the `libnss-docker` package.

The specific use of `perl` in this maintscript can be easily replaced
with an equivalent `sed` invocation.